### PR TITLE
Passthrough target can be built with request parameters

### DIFF
--- a/services/nodegate.js
+++ b/services/nodegate.js
@@ -52,7 +52,10 @@ const nodegate = () => {
   app.passthrough = (routes) => {
     toArray(routes).forEach((route) => {
       expressApp[route.method.toLowerCase()](route.path, (req, res) => {
-        request[route.method.toLowerCase()](route.target, {
+        const target = typeof route.target === 'function'
+          ? route.target(req)
+          : route.target;
+        request[route.method.toLowerCase()](target, {
           ...(req.headers && { headers: req.headers }),
           ...(req.body && { form: req.body }),
         }).pipe(res);

--- a/services/nodegate.js
+++ b/services/nodegate.js
@@ -53,7 +53,7 @@ const nodegate = () => {
     toArray(routes).forEach((route) => {
       expressApp[route.method.toLowerCase()](route.path, (req, res) => {
         const target = typeof route.target === 'function'
-          ? route.target(req)
+          ? route.target(req.params)
           : route.target;
         request[route.method.toLowerCase()](target, {
           ...(req.headers && { headers: req.headers }),

--- a/test/services/nodegate.test.js
+++ b/test/services/nodegate.test.js
@@ -142,6 +142,16 @@ describe('services/nodegate', () => {
         .expect(200);
       expect(text).toEqual('Multiline\nContent');
     });
+    it('should build the target url', async () => {
+      nock('http://service.com').get(/client\/[0-9]*/).reply(200);
+      const gate = nodegate();
+      gate.passthrough({
+        method: 'get',
+        path: '/client/:clientId',
+        target: (req) => `http://service.com/client/${req.params.clientId}`,
+      });
+      await request(gate).get('/client/123').expect(200);
+    });
   });
   describe('#use', () => {
     it('should work with express middlewares', async () => {

--- a/test/services/nodegate.test.js
+++ b/test/services/nodegate.test.js
@@ -148,7 +148,7 @@ describe('services/nodegate', () => {
       gate.passthrough({
         method: 'get',
         path: '/client/:clientId',
-        target: (req) => `http://service.com/client/${req.params.clientId}`,
+        target: (params) => `http://service.com/client/${params.clientId}`,
       });
       await request(gate).get('/client/123').expect(200);
     });


### PR DESCRIPTION
This PR allows to pass parameter to the target passthrough with the request params. Previously the target was only a string and all parameters wasn't evaluated. 
`target: 'service.com/client/:clientId'` => `:clientId` wasn't replace by the right value
You can now build the target with the request params:
```       
gate.passthrough({
  method: 'get',
  path: '/client/:clientId',
  target: (params) => `http://service.com/client/${params.clientId}`,
});
```