### PR TITLE
Feature/add custom error info on aggregates

### DIFF
--- a/docs/collections/_docs/errors-management.md
+++ b/docs/collections/_docs/errors-management.md
@@ -19,7 +19,7 @@ In case of error, the `statusCode` will be set to 500.
 
 ## Examples
 
-To answer a specific body with the error:
+To answer a specific body with an error that **will overwrite** the original error response:
 
 ```js
 gateway.route({
@@ -27,7 +27,7 @@ gateway.route({
   path: '/gateway-route',
   workflow: [...],
   onError: (error) => {
-    error.container.body = {
+    error.container.errorBody = {
       reason: 'An unknow error occurred.',
     };
   };

--- a/docs/collections/_workers/aggregate.md
+++ b/docs/collections/_workers/aggregate.md
@@ -31,6 +31,7 @@ The third argument `options` is an object accepting these keys:
  - `body`: object describing the body to send with the request, the values of each key must be an
  [object path](https://github.com/mariocasciaro/object-path){:target="_blank"} from the `container`.
  - `headers`: same usage as the body, but for the headers.
+ - `onError`: It's an object that will provide custom information to our response in case of failure.
 
 ## Examples
 
@@ -85,5 +86,37 @@ The reponse of a request matching this route will be like this one:
     "username": "anotherprofile",
     "birthdate": "1992-06-30"
   },
+}
+```
+
+### Custom errors
+
+You can set custom information when an error is triggered by a request,
+
+```js
+gateway.route({
+  method: 'get',
+  path: '/:username',
+  workflow: [
+    aggregate('get', `https://myapi.com/priceChecking?amount=xxx`, {
+      id: 'priceChecking',
+      onError: {
+        includeMetaInfo: true,
+        message: 'Custom and detailed message for this aggregate request',
+      },
+    }),
+  ],
+});
+```
+
+By setting up includeMetaInfo to "true" a meta field will be added to body with information about the aggregate function that threw the error:
+
+```json
+{
+    "meta": {
+        "url": "https://myapi.com/priceChecking?amount=xxx",
+        "id": "priceChecking"
+    },
+    "error": "Custom and detailed message for this aggregate request"
 }
 ```

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nodegate",
   "description": "API gateway made simple, fast and easy to configure.",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "author": "Julien Martin <martin.julien82@gmail.com>",
   "license": "MIT",
   "scripts": {

--- a/test/workers/aggregate.test.js
+++ b/test/workers/aggregate.test.js
@@ -209,5 +209,43 @@ describe('workers/aggregate', () => {
       )(container);
       expect(container.body.content).toEqual('This article does not exists');
     });
+    it('should set the container errorBody on with custom information', async () => {
+      expect.assertions(2);
+      const expectedMetaInfo = {
+        url: 'https://wiki.federation.com/armaments',
+        id: 'armaments',
+      };
+      try {
+        const container = getEmpty();
+        nock('https://wiki.federation.com').post('/armaments').reply(404);
+        await aggregate('post', 'https://wiki.federation.com/armaments', {
+          id: 'armaments',
+          onError: {
+            includeMetaInfo: true,
+          },
+        })(container);
+      } catch (err) {
+        expect(err.container.statusCode).toEqual(404);
+        expect(err.container.errorBody.meta).toEqual(expect.objectContaining(expectedMetaInfo));
+      }
+    });
+    it('should set the container errorBody on with custom information', async () => {
+      expect.assertions(2);
+      const expectedErrorMessage = 'not available armaments';
+      try {
+        const container = getEmpty();
+        nock('https://wiki.federation.com').post('/armaments').reply(404);
+        await aggregate('post', 'https://wiki.federation.com/armaments', {
+          id: 'armaments',
+          onError: {
+            includeMetaInfo: true,
+            message: expectedErrorMessage,
+          },
+        })(container);
+      } catch (err) {
+        expect(err.container.statusCode).toEqual(404);
+        expect(err.container.errorBody.error).toEqual(expectedErrorMessage);
+      }
+    });
   });
 });

--- a/workers/aggregate.js
+++ b/workers/aggregate.js
@@ -50,11 +50,18 @@ module.exports = (method, url, options = {}) => {
 
       const error = new WorkflowError(err, err.response);
       error.setContainer(container);
-      if (body) {
-        container.errorBody = body;
-      }
+      const { onError: { includeMetaInfo, message } = {}, ...restOptions } = options;
+      container.errorBody = (body || includeMetaInfo || message) && {
+        ...body,
+        ...(includeMetaInfo && {
+          meta: {
+            url,
+            ...restOptions,
+          },
+        }),
+        ...(message && { error: message }),
+      };
       container.statusCode = statusCode;
-
       throw error;
     }
   };


### PR DESCRIPTION
Now it's possible to include additional error information to "aggregate" workers on a request failure. This way, we can set different and customized messages that will be returned to the client.