### PR TITLE
Force json parsing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nodegate",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nodegate",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
         "body-parser": "~2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nodegate",
   "description": "API gateway made simple, fast and easy to configure.",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "author": "Julien Martin <martin.julien82@gmail.com>",
   "license": "MIT",
   "scripts": {

--- a/workers/aggregate.js
+++ b/workers/aggregate.js
@@ -44,7 +44,11 @@ module.exports = (method, url, options = {}) => {
       container.statusCode = response.status;
       if (response.headers.get('content-type') && !isJsonContentType(response.headers.get('content-type'))) {
         const text = await response.text();
-        setBodyToContainer(text, container, options);
+        setBodyToContainer(
+          container.headers['content-type'] === 'application/json' ? JSON.parse(text) : text,
+          container,
+          options,
+        );
         if (!response.ok) {
           throw new WorkflowError('Fetch error', { text, statusCode: response.status });
         }


### PR DESCRIPTION
related to https://github.com/weekendesk/tech-management/issues/1507

## Scope
Before version 2.0.0 we were using the deprecated library [request](https://github.com/request/request).
This library includes an option `json` set by default which [parses](https://github.com/request/request/blob/master/request.js#L1145) the response body as JSON.

We have some API endpoints with incorrect `content-type` which returns JSON as text in the body. 
As a workaround we want to force the json parsing if the request header contains `application/json`. 
This behaviour is the same than version <2.0.0.
