### PR TITLE
Update the CI setup which relies on deprecated @actions/cache

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'


### PR DESCRIPTION
The [CI is failing](https://github.com/weekendesk/nodegate/pull/97) because actions/setup-node@v2 relies on a deprecated package `@actions/cache`:
![image](https://github.com/user-attachments/assets/ac98a5b3-de7f-4011-ae93-b6920e5fa896)

I'm upgrading to the version 4.